### PR TITLE
Remove version from pixi.toml

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,13 +26,10 @@ jobs:
         with:
           name: artifact
           path: dist/*
-      - name: Make sure version in pyproject.toml and pixi.toml are in sync
-        run: |
-          [ "$(yq '.project.version' pixi.toml)" = "$(yq '.project.version' pyproject.toml)" ]
       - uses: Quantco/ui-actions/version-metadata@v1
         id: version-metadata
         with:
-          file: ./pixi.toml
+          file: ./pyproject.toml
           token: ${{ secrets.GITHUB_TOKEN }}
           version-extraction-override: 'regex:version = "(.*)"'
 

--- a/pixi.toml
+++ b/pixi.toml
@@ -2,7 +2,6 @@
 # https://github.com/prefix-dev/pixi/issues/79
 [project]
 name = "polarify"
-version = "0.1.3"
 description = "Simplifying conditional Polars Expressions with Python 🐍 🐻‍❄️"
 authors = ["Bela Stoyan <bela.stoyan@quantco.com>", "Pavel Zwerschke <pavel.zwerschke@quantco.com>"]
 channels = ["conda-forge"]


### PR DESCRIPTION
`version` is not necessary anymore since `pixi 0.7.0`.